### PR TITLE
Allow breaking changes in experimental plan — update AGENTS.md and TODO

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,8 @@
 # AGENTS.md — Vulfram instructions
 
 - Sempre que o usuário comentar sobre um padrão ou regra de desenvolvimento, adicionar ao `AGENTS.md`.
+- Planejamento deve ocorrer sem alterar arquivos (sem gerar codigo) quando o usuario pedir apenas analise.
+- Em fase experimental, nao precisamos manter retrocompatibilidade; comandos antigos podem ser removidos ao criar novos.
 - Variaveis que seguram ownership e não são mais usadas depois ganham sempre o prefixo `_`.
 - Se variaveis não forem usadas, devem ser removidas.
 - Funções não usadas também são removidas.
@@ -21,7 +23,7 @@
 - Recursos de áudio devem seguir o mesmo padrão de recursos de textura: IDs lógicos, bind a modelo para emissor/receptor, play com delay opcional e modo (once/loop/reverse/loop-reverse/ping-pong), e bypass de spatialização quando emissor e receptor forem o mesmo modelo.
 - O sistema de áudio deve separar resource de source: source e listener são vinculados a modelos; play recebe resourceId e timelineId (default 0), reinicia se timeline já estiver ativo; stop pode receber timelineId.
 - Arquitetura de render deve introduzir `Realm`, `Surface` e `RealmGraph`: `RenderGraph` fica intra-Realm; `RealmGraph` auto-gerado entre Realms a partir de Connectors e Presents.
-- `CmdRenderGraphSet(windowId, graph)` continua existindo como compat layer e passa a ser alias do RenderGraph do Realm default da window.
+- `CmdRenderGraphSet` deve passar a configurar o RenderGraph do Realm 3D; planejar renomear para `CmdRenderGraph3DSet` e futuramente introduzir o comando do Realm 2D.
 - `Surface` deve ser sempre renderizavel e sampleavel (virtual swapchain), com conversoes automaticas de formato/alpha/size e resolve de MSAA quando necessario.
 - Composicao inter-Realm ocorre via `PlaneConnector` (3D) e `ViewportConnector` (2D/UI), com roteamento de input via hit-test/raycast e foco/capture.
 - `RealmGraph` deve impedir deadlocks: ciclos sao quebrados de forma deterministica com cache `LastGoodSurface` ou `FallbackSurface`; leitura do proprio output corrente e proibida por padrao (permitir apenas `PreviousFrame`).

--- a/TODO.md
+++ b/TODO.md
@@ -4,6 +4,7 @@
 
 **Fase 0 — Preparacao e alinhamento tecnico**
 - [ ] Mapear o fluxo atual de render por window e os pontos de acoplamento (`WindowState.render_state`, `render_frames`, `CmdRenderGraphSet`).
+- [ ] Definir a separacao de estados: `EngineState` (global), `WindowState` (janela), `InputsState` (teclado/ponteiro/gamepad), `UniversalState` (tabelas globais), `RealmState` (por realm).
 - [ ] Definir o contrato interno de `Realm`, `Surface`, `Present` e `Connector` (campos minimos, defaults e lifecycle).
 - [ ] Definir como os IDs logicos novos (`RealmId`, `SurfaceId`, `ConnectorId`, `PresentId`) aparecem no core (tabelas + generation).
 - [ ] Definir a politica de buffering do `Surface` (min 2 imagens, prev/current) e como expor `PreviousFrame`.
@@ -12,16 +13,18 @@
 - [ ] Validar o impacto no profiling e GPU timestamps com execucao multi-realm.
 - [ ] Atualizar docs de arquitetura (planejamento) antes de iniciar implementacao pesada.
 
-**Fase A — Infraestrutura base + Compatibilidade (sem mudar o host)**
+**Fase A — Infraestrutura base (sem retrocompatibilidade)**
 - [ ] Criar `RealmTable` com generation e estados essenciais (kind, output_surface, render_graph, flags).
 - [ ] Criar `SurfaceTable` com generation, `kind` (onscreen/offscreen), size/format/alpha/msaa policies e buffering.
 - [ ] Criar `PresentTable` com mapping `windowId -> surfaceId` e defaults.
 - [ ] Criar `ConnectorTable` com campos minimos: `connectorId`, `kind`, `sourceSurfaceId`, `rect`, `zIndex`, `blendMode`, `clip`, `inputFlags`.
+- [ ] Realocar estado do sistema de audio para o `UniversalState` e bindings por `RealmState` (sem mexer em detalhes internos).
+- [ ] Migrar bind de audio para `realmId` em vez de `windowId` (listener e source).
 - [ ] Introduzir `Realm` default por window (criado junto com `CmdWindowCreate`).
 - [ ] Criar `Surface` onscreen por window (virtual swapchain) e registrar em `Present`.
-- [ ] Ajustar `CmdRenderGraphSet(windowId, graph)` para ser alias do `Realm` default da window.
-- [ ] Garantir que o render atual continue funcionando sem host changes.
-- [ ] Atualizar docs de `CmdRenderGraphSet` para mencionar o alias do Realm default.
+- [ ] Substituir `CmdRenderGraphSet` por `CmdRenderGraph3DSet` (remover comando antigo).
+- [ ] Criar o comando de RenderGraph para Realm 2D (par 2D do `CmdRenderGraph3DSet`).
+- [ ] Atualizar docs dos comandos de RenderGraph para refletir a divisao 3D/2D.
 - [ ] Atualizar docs de `RENDER-GRAPH` para esclarecer que e intra-Realm.
 
 **Fase B — RealmGraph minimo (composicao visual basica)**


### PR DESCRIPTION
### Motivation
- Clarify project policy to allow breaking changes during the experimental phase so the roadmap can replace old commands with new designs. 
- Remove the implicit compatibility constraint from Phase A planning so the architecture migration can be planned as a breaking change. 

### Description
- Added guidance to `AGENTS.md` stating that in the experimental phase backward compatibility is not required and old commands may be removed when introducing new ones. 
- Updated `TODO.md` Phase 0 to define separation of states via `EngineState`, `WindowState`, `InputsState`, `UniversalState`, and `RealmState`. 
- Revised `TODO.md` Phase A to drop compatibility framing and to replace `CmdRenderGraphSet` with `CmdRenderGraph3DSet` while adding a planned 2D RenderGraph command and related documentation updates. 
- Added planned audio migration tasks to `TODO.md` to relocate audio state to `UniversalState` and bind audio by `realmId`. 

### Testing
- Ran `cargo check --lib`, which failed due to the system dependency for `alsa-sys` not being available (pkg-config could not find `alsa.pc`). 
- No unit or integration tests were added or run for these documentation and plan changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69868c3ebe6c83289682ccbbd4aab8cb)